### PR TITLE
Adding more options to voxelreuseplot

### DIFF
--- a/src/plot_recipes.jl
+++ b/src/plot_recipes.jl
@@ -38,7 +38,7 @@
   # save support as an array
   ts = collect(tmin:tmax)
 
-  # compute voxel reuse
+  # -- compute voxel reuse
   extent = size(img)
   idx = [extent...] .> 1
 
@@ -55,6 +55,7 @@
 
     next!(p)
   end
+  # --
 
   # highlight the optimum template range
   @series begin

--- a/src/voxel_reuse.jl
+++ b/src/voxel_reuse.jl
@@ -18,7 +18,7 @@
                overlapx::Real=1/6, overlapy::Real=1/6, overlapz::Real=1/6,
                cut::Symbol=:boykov, simplex::Bool=false, nreal::Integer=10,
                threads::Integer=CPU_PHYSICAL_CORES, gpu::Bool=false,
-			   soft::AbstractVector=[], hard::HardData=HardData(), tol::Real=.1) #this last line was added
+			   soft::AbstractVector=[], hard::HardData=HardData(), tol::Real=.1)
 
 Returns the mean voxel reuse in `[0,1]` and its standard deviation.
 

--- a/src/voxel_reuse.jl
+++ b/src/voxel_reuse.jl
@@ -17,7 +17,8 @@
                tplsizex::Integer, tplsizey::Integer, tplsizez::Integer;
                overlapx::Real=1/6, overlapy::Real=1/6, overlapz::Real=1/6,
                cut::Symbol=:boykov, simplex::Bool=false, nreal::Integer=10,
-               threads::Integer=CPU_PHYSICAL_CORES, gpu::Bool=false)
+               threads::Integer=CPU_PHYSICAL_CORES, gpu::Bool=false,
+			   soft::AbstractVector=[], hard::HardData=HardData(), tol::Real=.1) #this last line was added
 
 Returns the mean voxel reuse in `[0,1]` and its standard deviation.
 
@@ -29,7 +30,8 @@ function voxelreuse(training_image::AbstractArray,
                     tplsizex::Integer, tplsizey::Integer, tplsizez::Integer;
                     overlapx::Real=1/6, overlapy::Real=1/6, overlapz::Real=1/6,
                     cut::Symbol=:boykov, simplex::Bool=false, nreal::Integer=10,
-                    threads::Integer=CPU_PHYSICAL_CORES, gpu::Bool=false)
+                    threads::Integer=CPU_PHYSICAL_CORES, gpu::Bool=false,
+					soft::AbstractVector=[], hard::HardData=HardData(), tol::Real=.1)
 
   # calculate the overlap from given percentage
   ovx = ceil(Int, overlapx * tplsizex)
@@ -51,7 +53,8 @@ function voxelreuse(training_image::AbstractArray,
                      gridsizex, gridsizey, gridsizez,
                      overlapx=overlapx, overlapy=overlapy, overlapz=overlapz,
                      cut=cut, simplex=simplex, nreal=nreal,
-                     threads=threads, gpu=gpu, debug=true)
+                     threads=threads, gpu=gpu, debug=true,
+					 soft=soft,hard=hard,tol=tol)
 
   μ = mean(voxs)
   σ = std(voxs, mean=μ)


### PR DESCRIPTION
**For voxel_reuse.jl** 
All I did was add in more options to the function `voxelreuse` so that it had the same arguments as `iqsim`.

**For plot_recipes.jl**
I modified the plotting function to use more arguments. Passing more arguments through `voxelreuseplot` required the function `mapreuse` to also pass identical arguments. Since `mapreuse` only appeared once I figured it would be fine to delete it and paste its contents directly into the main plotting function. 

The `voxelreuseplot` function seems to work as expected with additional arguments now although the progress bar gets messed up when using GPU.